### PR TITLE
Fix date format

### DIFF
--- a/stadtreinigung_hamburg/StadtreinigungHamburg.py
+++ b/stadtreinigung_hamburg/StadtreinigungHamburg.py
@@ -82,22 +82,7 @@ class StadtreinigungHamburg:
         return collections
 
 def parseDate(text):
-    text = text[3:] #remove 3 letters for abbreviated day of week
-    text = text.replace("Januar","01.")
-    text = text.replace("Februar","02.")
-    text = text.replace("März","03.")
-    text = text.replace("April","04.")
-    text = text.replace("Mai","05.")
-    text = text.replace("Juni","06.")
-    text = text.replace("Juli","07.")
-    text = text.replace("August","08.")
-    text = text.replace("September","09.")
-    text = text.replace("Oktober","10.")
-    text = text.replace("November","11.")
-    text = text.replace("Dezember","12.")
-    text = text.strip()
-
-    return datetime.strptime(text, '%d. %m. %Y')
+    return datetime.strptime(text, "%a %d. %B %Y")
 
 class StreetNotFoundException(Exception):
     pass


### PR DESCRIPTION
It looks like the "API" now returns English names for months in this format:
```
Mon 30. June 2025
Mon 30. June 2025
Wed 02. July 2025
Wed 02. July 2025
Thu 03. July 2025
Thu 03. July 2025
Thu 10. July 2025
Thu 10. July 2025
Fri 11. July 2025
Fri 11. July 2025
Mon 14. July 2025
Mon 14. July 2025
Wed 16. July 2025
Wed 16. July 2025
Thu 17. July 2025
Thu 17. July 2025
Thu 24. July 2025
Thu 24. July 2025
Mon 28. July 2025
Mon 28. July 2025
```
This change works for me.